### PR TITLE
Remove Autocopy

### DIFF
--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/CopyTensor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/CopyTensor.sv
@@ -18,6 +18,8 @@ top::Expr ::= l::Expr r::Expr
       r.pp
     ]);
 
+  propagate controlStmtContext, env;
+
   local formatL :: TensorFormat =
     case l.typerep of
     | extType(_, tensorType(f)) -> new(f.tensorFormat)

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/FreeTensor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/FreeTensor.sv
@@ -15,6 +15,8 @@ top::Expr ::= tensor::Expr
       text(")")
     ]);
 
+  propagate controlStmtContext, env;
+
   local format::Name =
     case tensor.typerep of
     | extType(_, tensorType(fmt)) -> fmt

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/Overload.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/Overload.sv
@@ -21,6 +21,8 @@ top::Expr ::= t::TypeName exs::[Expr]
       ++
       [text(")")]
     );
+
+  propagate controlStmtContext, env;
   
   forwards to
     case t.typerep.buildProd of

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/Syntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/build/Syntax.sv
@@ -11,6 +11,8 @@ import edu:umn:cs:melt:exts:ableC:tensorAlgebra;
 abstract production build_empty
 top::Expr ::= type::TypeName dims::[Expr]
 {
+  propagate controlStmtContext, env;
+
   local format::Name =
     case type.typerep of
     | extType(_, tensorType(fmt)) -> fmt
@@ -97,6 +99,9 @@ top::Expr ::= type::TypeName dims::[Expr]
 abstract production build_data
 top::Expr ::= type::TypeName data::TensorConstant
 {
+  propagate controlStmtContext;
+  type.env = top.env;
+
   local format::Name =
     case type.typerep of
     | extType(_, tensorType(fmt)) -> fmt
@@ -160,6 +165,8 @@ top::Expr ::= type::TypeName data::TensorConstant
 abstract production buildTensorExpr
 top::Expr ::= type::TypeName args::[Expr]
 {
+  propagate controlStmtContext, env;
+
   local dims::Expr = head(args);
   
   local format::Name = 

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/expr/TensorExpr.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/expr/TensorExpr.sv
@@ -27,11 +27,11 @@ synthesized attribute iterAccess :: [Either<Expr String>];
 -- Setting remaining and querying isAvail tells whether
 -- at the current position in the codegen a TensorExpr
 -- is available to calculate.
-autocopy attribute remaining :: [String];
+inherited attribute remaining :: [String];
 synthesized attribute isAvail :: Boolean;
 
 -- The variable that is currently used (being queried of)
-autocopy attribute variable :: String;
+inherited attribute variable :: String;
 
 -- Various ways to determine if layers are dense or sparse.
 -- sparse(_r) and dense(_r) list all dimensions (tensor name and

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/expr/TensorExpr.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/expr/TensorExpr.sv
@@ -27,11 +27,11 @@ synthesized attribute iterAccess :: [Either<Expr String>];
 -- Setting remaining and querying isAvail tells whether
 -- at the current position in the codegen a TensorExpr
 -- is available to calculate.
-autocopy attribute remaining :: [String];
+inherited attribute remaining :: [String];
 synthesized attribute isAvail :: Boolean;
 
 -- The variable that is currently used (being queried of)
-autocopy attribute variable :: String;
+inherited attribute variable :: String;
 
 -- Various ways to determine if layers are dense or sparse.
 -- sparse(_r) and dense(_r) list all dimensions (tensor name and
@@ -47,6 +47,9 @@ nonterminal TensorExpr with
   tensors, exprs, remaining, isAvail, 
   variable, fmts, sparse, dense, sparse_r, dense_r,
   iterAccess, location;
+propagate remaining on TensorExpr;
+propagate variable on TensorExpr;
+propagate fmts on TensorExpr;
 
 -- A TensorExpr that is simple an ableC Expr
 abstract production tensorBaseExpr

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/foreach/Foreach.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/foreach/Foreach.sv
@@ -19,6 +19,8 @@ top::Stmt ::= var::Name bounds::Expr body::Stmt
       body.pp
    ]);
 
+  bounds.controlStmtContext = top.controlStmtContext;
+
   bounds.env = top.env;
 
   local tensorAcc :: Boolean =

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/format/Syntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/format/Syntax.sv
@@ -9,6 +9,8 @@ import edu:umn:cs:melt:exts:ableC:tensorAlgebra;
 abstract production format
 top::Decl ::= nm::Name specs::[Integer] order::[Integer]
 {
+  propagate controlStmtContext, env;
+
   local errors::[Message] =
     checkTensorHeader(nm.location, top.env)
     ++

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/halide/HalideExpr.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/halide/HalideExpr.sv
@@ -11,6 +11,8 @@ top::Stmt ::= output::Name expr::Expr
   top.functionDefs := [];
   top.labelDefs := [];
 
+  propagate controlStmtContext, env;
+
   local out::TensorExpr =
     tensorBaseExpr(
       declRefExpr(
@@ -219,6 +221,8 @@ top::Stmt ::= output::Name expr::Expr access::[String]
   top.functionDefs := [];
   top.labelDefs := [];
 
+  propagate controlStmtContext, env;
+
   local out::TensorExpr =
     tensorBaseExpr(
       declRefExpr(
@@ -421,6 +425,8 @@ top::Stmt ::= tensor::Expr idx::Expr value::Expr
     ]);
   top.functionDefs := [];
   top.labelDefs := [];
+
+  propagate controlStmtContext, env;
     
   local out::TensorExpr =
     tensorAccess(tensor, idx, top.env, location=tensor.location);
@@ -724,6 +730,8 @@ top::Stmt ::= tensor::Expr idx::Expr value::Expr access::[String]
     ]);
   top.functionDefs := [];
   top.labelDefs := [];
+
+  propagate controlStmtContext, env;
 
   local out::TensorExpr =
     tensorAccess(tensor, idx, top.env, location=tensor.location);

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/halide/Setup.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/halide/Setup.sv
@@ -12,6 +12,9 @@ top::Stmt ::= tensor::Expr idx::Expr value::Expr inner::Stmt
   top.functionDefs := [];
   top.labelDefs := [];
 
+  propagate controlStmtContext;
+  value.env = top.env;
+
   local out::TensorExpr = -- Build the output into a TensorExpr
     tensorAccess(tensor, idx, top.env, location=tensor.location);
   local ex::TensorExpr = -- Get the rhs's TensorExpr
@@ -331,6 +334,9 @@ top::Stmt ::= output::Name expr::Expr inner::Stmt
   top.pp = text("// Halide Tensor Expr Setup");
   top.functionDefs := [];
   top.labelDefs := [];
+
+  propagate controlStmtContext;
+  expr.env = top.env;
 
   local ex::TensorExpr =
     expr.tensorExp;

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/halide/Syntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/halide/Syntax.sv
@@ -19,6 +19,8 @@ top::Stmt ::= tns::Expr idx::Expr val::Expr ts::Transformation
   top.functionDefs := [];
   top.labelDefs := [];
 
+  propagate controlStmtContext, env;
+
   local out::TensorExpr =
     tensorAccess(tns, idx, top.env, location=tns.location);
   local ex::TensorExpr =
@@ -228,6 +230,8 @@ top::Stmt ::= tns::Expr idx::Expr val::Expr ord::[String] ts::Transformation
   top.functionDefs := [];
   top.labelDefs := [];
 
+  propagate controlStmtContext, env;
+
   local out::TensorExpr =
     tensorAccess(tns, idx, top.env, location=tns.location);
   local ex::TensorExpr =
@@ -432,6 +436,8 @@ top::Stmt ::= nm::Name val::Expr ts::Transformation
   top.functionDefs := [];
   top.labelDefs := [];
 
+  propagate controlStmtContext, env;
+
   local ex::TensorExpr =
     val.tensorExp;
 
@@ -570,6 +576,8 @@ top::Stmt ::= nm::Name val::Expr ord::[String] ts::Transformation
     ]);
   top.functionDefs := [];
   top.labelDefs := [];
+
+  propagate controlStmtContext, env;
 
   local ex::TensorExpr =
     val.tensorExp;

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/lattice/MergeLattice.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/lattice/MergeLattice.sv
@@ -12,7 +12,7 @@ synthesized attribute value :: TensorExpr; -- a TensorExpr of the rhs
 synthesized attribute cond :: TensorCond; -- the condition for this merge
 synthesized attribute pnts :: [LatticePoint]; -- subpoints
 
-autocopy attribute fmts :: tm:Map<String TensorFormat>;
+inherited attribute fmts :: tm:Map<String TensorFormat>;
 
 nonterminal LatticePoint with value, fmts, cond, pnts;
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/lattice/MergeLattice.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/lattice/MergeLattice.sv
@@ -12,9 +12,10 @@ synthesized attribute value :: TensorExpr; -- a TensorExpr of the rhs
 synthesized attribute cond :: TensorCond; -- the condition for this merge
 synthesized attribute pnts :: [LatticePoint]; -- subpoints
 
-autocopy attribute fmts :: tm:Map<String TensorFormat>;
+inherited attribute fmts :: tm:Map<String TensorFormat>;
 
 nonterminal LatticePoint with value, fmts, cond, pnts;
+propagate fmts on LatticePoint;
 
 abstract production latticePoint
 top::LatticePoint ::= pnts::[LatticePoint] value::TensorExpr cond::TensorCond

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/AddTensor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/AddTensor.sv
@@ -11,6 +11,8 @@ top::Expr ::= l::Expr r::Expr
              r.pp
            ]);
 
+  propagate controlStmtContext, env;
+
   top.tensorExp =
     tensorAdd(l.tensorExp, r.tensorExp, top.env, location=top.location);
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/DivTensor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/DivTensor.sv
@@ -14,6 +14,8 @@ top::Expr ::= l::Expr r::Expr
   top.tensorExp =
     tensorDiv(l.tensorExp, r.tensorExp, top.env, location=top.location);
 
+  propagate controlStmtContext, env;
+
   forwards to 
     mkErrorCheck(
       l.errors ++ r.errors,

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/MemberAccess.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/MemberAccess.sv
@@ -10,6 +10,8 @@ top::Expr ::= tensor::Expr deref::Boolean nm::Name
     then pp"${tensor.pp}->${text(nm.name)}"
     else pp"${tensor.pp}.${text(nm.name)}";
 
+  propagate controlStmtContext, env;
+
   local fmt::TensorFormat =
     case tensor.typerep of
     | extType(_, tensorType(f)) -> new(f.tensorFormat)

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/MulTensor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/MulTensor.sv
@@ -14,6 +14,8 @@ top::Expr ::= l::Expr r::Expr
   top.tensorExp =
     tensorMul(l.tensorExp, r.tensorExp, top.env, location=top.location);
 
+  propagate controlStmtContext, env;
+
   forwards to 
     mkErrorCheck(
       l.errors ++ r.errors,

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/SubTensor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/SubTensor.sv
@@ -11,6 +11,8 @@ top::Expr ::= l::Expr r::Expr
              r.pp
            ]);
 
+  propagate controlStmtContext, env;
+
   top.tensorExp =
     tensorSub(l.tensorExp, r.tensorExp, top.env, location=top.location);
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/TensorAccess.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/TensorAccess.sv
@@ -7,6 +7,7 @@ import edu:umn:cs:melt:exts:ableC:tensorAlgebra;
 abstract production accessTensor
 top::Expr ::= tensor::Expr idx::Expr
 {
+  propagate controlStmtContext, env;
 
   top.tensorExp =
     tensorAccess(tensor, idx, top.env, location=top.location);

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/TensorAssign.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/TensorAssign.sv
@@ -10,6 +10,7 @@ import edu:umn:cs:melt:exts:ableC:tensorAlgebra;
 abstract production accessTensorAssign
 top::Expr ::= tensor::Expr idx::Expr right::Expr
 {
+  propagate controlStmtContext, env;
 
   -- Whether the right side of the expression is a tensor_acc or
   -- An actual value

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/TensorExprAssign.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/ovrld/TensorExprAssign.sv
@@ -18,6 +18,8 @@ top::Expr ::= tensor::Expr idx::Expr right::Expr
       text("] = "),
       right.pp
     ]);
+
+  propagate controlStmtContext, env;
   
   local out::TensorExpr =
     tensorAccess(tensor, idx, top.env, location=top.location);
@@ -602,6 +604,8 @@ top::Expr ::= output::Expr expr::Expr
       text(" = "),
       expr.pp
     ]);
+
+  propagate controlStmtContext, env;
 
   local out::TensorExpr =
     tensorBaseExpr(

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/type/Type.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/type/Type.sv
@@ -11,6 +11,8 @@ top::BaseTypeExpr ::= q::Qualifiers fmt::Name
   local localErrors::[Message] =
     checkTensorHeader(fmt.location, top.env) ++ fmt.tensorFormatLookupCheck;
   
+  propagate env;
+
   forwards to
     if !null(localErrors)
     then errorTypeExpr(localErrors)

--- a/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/utils/Syntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.tensorAlgebra/abstractsyntax/utils/Syntax.sv
@@ -13,6 +13,8 @@ top::Expr ::= tp::TypeName
       text(")")
     ]);
 
+  propagate controlStmtContext, env;
+
   forwards to orderof(tp.typerep, location=top.location);
 }
 
@@ -26,6 +28,8 @@ top::Expr ::= e::Expr
       e.pp,
       text(")")
     ]);
+
+  propagate controlStmtContext, env;
 
   forwards to 
     mkErrorCheck(
@@ -85,6 +89,8 @@ top::Expr ::= tensor::Expr dim::Expr
       dim.pp,
       text("]")
     ]);
+
+  propagate controlStmtContext, env;
 
   local lErrors::[Message] =
     checkTensorHeader(top.location, top.env)


### PR DESCRIPTION
This removes `autocopy` and inserts `propagate`s to fix the flow errors resulting from removing `autocopy` here and in AbleC.